### PR TITLE
feat: Validate onchange after submit

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -1,4 +1,4 @@
-import { computed } from 'mobx';
+import { computed, observable } from 'mobx';
 import _ from 'lodash';
 
 import {
@@ -23,12 +23,18 @@ export default class Base {
     this.noop,
   ).apply(this, [...args]), this.execHook(name)];
 
+  @observable $submitCount = 0;
+
   @computed get hasIncrementalKeys() {
     return (this.fields.size && hasIntKeys(this.fields));
   }
 
   @computed get hasNestedFields() {
     return (this.fields.size !== 0);
+  }
+
+  @computed get hasSubmitted() {
+    return this.$submitCount > 0;
   }
 
   @computed get size() {

--- a/src/Form.js
+++ b/src/Form.js
@@ -17,7 +17,6 @@ export default class Form extends Base {
 
   @observable $submitting = false;
   @observable $validating = false;
-  @observable $submitCount = 0;
 
   @observable fields = observable.map ? observable.map({}) : asMap({});
 
@@ -76,10 +75,6 @@ export default class Form extends Base {
 
   /* ------------------------------------------------------------------ */
   /* COMPUTED */
-
-  @computed get hasSubmitted() {
-    return this.$submitCount > 0;
-  }
 
   @computed get submitting() {
     return this.$submitting;

--- a/src/Options.js
+++ b/src/Options.js
@@ -18,6 +18,7 @@ export default class Options {
     validateOnBlur: true,
     validateOnChange: false,
     validateOnChangeAfterInitialBlur: false,
+    validateOnChangeAfterSubmit: false,
     validateDisabledFields: false,
     strictUpdate: false,
     strictDelete: true,

--- a/src/shared/Actions.js
+++ b/src/shared/Actions.js
@@ -20,9 +20,7 @@ export default {
   submit(o = {}) {
     this.$submitting = true;
 
-    if (_.has(this, '$submitCount')) {
-      this.$submitCount += 1;
-    }
+    this.$submitCount += 1;
 
     const exec = isValid => isValid
       ? this.execHook('onSuccess', o)

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { values as mobxValues, keys as mobxKeys } from 'mobx';
 
 const props = {
-  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing', 'hasBlurred'],
+  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing', 'blurred', 'hasSubmitted'],
   field: ['value', 'initial', 'default', 'label', 'placeholder', 'disabled', 'related', 'options', 'extra', 'bindings', 'type', 'hooks', 'handlers', 'error'],
   separated: ['values', 'initials', 'defaults', 'labels', 'placeholders', 'disabled', 'related', 'options', 'extra', 'bindings', 'types', 'hooks', 'handlers'],
   handlers: ['onChange', 'onToggle', 'onFocus', 'onBlur', 'onDrop', 'onSubmit', 'onReset', 'onClear', 'onAdd', 'onDel'],
@@ -14,11 +14,12 @@ const props = {
     isPristine: 'every',
     isDefault: 'every',
     isEmpty: 'every',
-    hasBlurred: 'some',
+    blurred: 'some',
     hasError: 'some',
     focused: 'some',
     touched: 'some',
     changed: 'some',
+    hasSubmitted: 'some',
     disabled: 'every',
     clearing: 'every',
     resetting: 'every',

--- a/tests/flat.submit.js
+++ b/tests/flat.submit.js
@@ -8,6 +8,7 @@ describe('Form submit() decoupled callback', () => {
     $.$I.submit({
       onSuccess: (form) => {
         expect(form.$submitCount).to.equal(1);
+        expect(form.hasSubmitted).to.be.true; // eslint-disable-line
         expect(form.isValid).to.be.true; // eslint-disable-line
         done();
       },
@@ -19,6 +20,7 @@ describe('Form submit() decoupled callback', () => {
     $.$N.submit({
       onError: (form) => {
         expect(form.$submitCount).to.equal(1);
+        expect(form.hasSubmitted).to.be.true; // eslint-disable-line
         expect(form.isValid).to.be.false; // eslint-disable-line
         done();
       },

--- a/tests/nested.submit.js
+++ b/tests/nested.submit.js
@@ -6,6 +6,8 @@ describe('Nested Form Manual submit()', () => {
   // $R
   it('$R.submit() should call onSuccess callback', (done) => {
     $.$R.$('members').submit().then((instance) => {
+      expect(instance.$submitCount).to.equal(1);
+      expect(instance.hasSubmitted).to.be.true; // eslint-disable-line
       expect(instance.isValid).to.be.true; // eslint-disable-line
       done();
     });


### PR DESCRIPTION
- `submitCount` observable on form/field objects
- `hasSubmitted` computed on form/field objects
- changed `hasBlurred` to `blurred` to be consistent with the mobx-react-form origin (my stuff got merged with the naming change)